### PR TITLE
Refer to Apple's operating system as macOS

### DIFF
--- a/download.md
+++ b/download.md
@@ -32,7 +32,7 @@ Then add the following to your `.emacs`:
 (load "~/.emacs.d/lisp/PG/generic/proof-site")
 ```
 
-If Proof General complains about a version mismatch, make sure that the shell's `emacs` is indeed your usual Emacs. If not, run the Makefile again with an explicit path to Emacs. On Mac in particular you'll probably need something like
+If Proof General complains about a version mismatch, make sure that the shell's `emacs` is indeed your usual Emacs. If not, run the Makefile again with an explicit path to Emacs. On macOS in particular you'll probably need something like
 
 ```sh
 make clean; make EMACS=/Applications/Emacs.app/Contents/MacOS/Emacs
@@ -55,7 +55,7 @@ You need:
 - Version 24.3 or later of [GNU Emacs](http://www.gnu.org/software/emacs/).
 
 Emacs is available for a huge variety of platforms, including Unix,
-Windows, and Mac OS. See the [Emacs Wiki](http://www.emacswiki.org)
+Windows, and macOS. See the [Emacs Wiki](http://www.emacswiki.org)
 for advice.
 
 {% comment %} TODO: setup a wiki on GitHub?

--- a/index.md
+++ b/index.md
@@ -76,7 +76,7 @@ Then add the following to your `.emacs`:
 (load "~/.emacs.d/lisp/PG/generic/proof-site")
 ```
 
-If Proof General complains about a version mismatch, make sure that the shell's `emacs` is indeed your usual Emacs. If not, run the Makefile again with an explicit path to Emacs. On Mac in particular you'll probably need something like
+If Proof General complains about a version mismatch, make sure that the shell's `emacs` is indeed your usual Emacs. If not, run the Makefile again with an explicit path to Emacs. On macOS in particular you'll probably need something like
 
 ```sh
 make clean; make EMACS=/Applications/Emacs.app/Contents/MacOS/Emacs


### PR DESCRIPTION
Since version 10.12 "Sierra", the operating system is now called macOS
rather than (Mac) OS X.
